### PR TITLE
Remove unused #define

### DIFF
--- a/PSTModernizer/PSTModernizer.mm
+++ b/PSTModernizer/PSTModernizer.mm
@@ -23,8 +23,6 @@
 #define PSTClassObfuscate(...) NSClassFromString([NSString stringWithFormat:__VA_ARGS__])
 #define PSTSELObfuscate(...) NSSelectorFromString([NSString stringWithFormat:__VA_ARGS__])
 
-#define PST_STATIC extern "C" 
-
 // iOS 10 compatibility
 #ifndef kCFCoreFoundationVersionNumber_iOS_10_0
 #define kCFCoreFoundationVersionNumber_iOS_10_0 1300.0


### PR DESCRIPTION
I can't see a single use of PST_STATIC in this file, therefore I think less code – better.
